### PR TITLE
Build only master branch on CI on pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ node_js:
 script:
   - npm test
   - npm run lint
+branches:
+  only:
+    - master


### PR DESCRIPTION
Now each PR from the same repo is built twice: as a push and as a PR. This commit restricts push-initiated CI builds to master branch only.