### PR TITLE
Fixed wrong combined path on windows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+sandboxed-fs package is licensed to use as follows:
+
+"""
 MIT License
 
 Copyright (c) 2017 Metarhia contributors
@@ -19,3 +22,85 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+"""
+
+This license applies to parts of sandboxed-fs originating from the
+https://github.com/jonschlinkert/is-unc-path repository:
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2017, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+This license applies to parts of sandboxed-fs originating from the
+https://github.com/regexhq/unc-path-regex repository:
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+This license applies to parts of sandboxed-fs originating from the
+https://github.com/jonschlinkert/is-windows repository:
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2017, Jon Schlinkert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""

--- a/package.json
+++ b/package.json
@@ -31,9 +31,5 @@
   "scripts": {
     "test": "node ./test.js",
     "lint": "eslint ."
-  },
-  "dependencies": {
-    "is-unc-path": "^1.0.0",
-    "is-windows": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
   "scripts": {
     "test": "node ./test.js",
     "lint": "eslint ."
+  },
+  "dependencies": {
+    "is-unc-path": "^1.0.0",
+    "is-windows": "^1.0.1"
   }
 }

--- a/sandboxed-fs.js
+++ b/sandboxed-fs.js
@@ -13,12 +13,14 @@ const errorMessage = 'path must be a string';
 function makePathSafe(path) {
   const safePath = pathModule.resolve('/', path);
 
-  // As Windows is the only non-UNIX like platform supported by node (https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1)
+  // As Windows is the only non-UNIX like platform supported by node
+  // https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1
   if (isWindows()) {
     if (isUncPath(safePath)) {
       return safePath.substring(pathModule.parse(safePath).root.length);
     } else {
-      // If the path is a non-unc path on windows, the root is fixed to 3 characters like 'C:\'
+      // If the path is a non-unc path on windows, the root is fixed to 3
+      // characters like 'C:\'
       return safePath.substring(3);
     }
   }

--- a/sandboxed-fs.js
+++ b/sandboxed-fs.js
@@ -5,13 +5,25 @@ module.exports = sandboxedFs;
 
 const fs = require('fs');
 const pathModule = require('path');
+const isWindows = require('is-windows');
+const isUncPath = require('is-unc-path');
 
 const errorMessage = 'path must be a string';
 
 function makePathSafe(path) {
   const safePath = pathModule.resolve('/', path);
 
-  return safePath.substring(pathModule.parse(safePath).root.length);
+  // As Windows is the only non-UNIX like platform supported by node (https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1)
+  if (isWindows()) {
+    if (isUncPath(safePath)) {
+      return safePath.substring(pathModule.parse(safePath).root.length);
+    } else {
+      // If the path is a non-unc path on windows, the root is fixed to 3 characters like 'C:\'
+      return safePath.substring(3);
+    }
+  }
+
+  return safePath;
 }
 
 const pathFunctionsWrapper = (func, path) => (p, ...args) => {

--- a/sandboxed-fs.js
+++ b/sandboxed-fs.js
@@ -8,8 +8,8 @@ const pathModule = require('path');
 const isWindows = process.platform === 'win32' ||
       process.env.OSTYPE === 'cygwin' ||
       process.env.OSTYPE === 'msys';
-const isUncPath = function (path) {
-  return /^[\\\/]{2,}[^\\\/]+[\\\/]+[^\\\/]+/.test(path);
+const isUncPath = function(path) {
+  return /^[\\/]{2,}[^\\/]+[\\/]+[^\\/]+/.test(path);
 };
 
 const errorMessage = 'path must be a string';

--- a/sandboxed-fs.js
+++ b/sandboxed-fs.js
@@ -9,7 +9,9 @@ const pathModule = require('path');
 const errorMessage = 'path must be a string';
 
 function makePathSafe(path) {
-  return pathModule.resolve('/', path);
+  const safePath = pathModule.resolve('/', path);
+
+  return safePath.substring(pathModule.parse(safePath).root.length);
 }
 
 const pathFunctionsWrapper = (func, path) => (p, ...args) => {

--- a/sandboxed-fs.js
+++ b/sandboxed-fs.js
@@ -5,8 +5,12 @@ module.exports = sandboxedFs;
 
 const fs = require('fs');
 const pathModule = require('path');
-const isWindows = require('is-windows');
-const isUncPath = require('is-unc-path');
+const isWindows = process.platform === 'win32' ||
+      process.env.OSTYPE === 'cygwin' ||
+      process.env.OSTYPE === 'msys';
+const isUncPath = function (path) {
+  return /^[\\\/]{2,}[^\\\/]+[\\\/]+[^\\\/]+/.test(path);
+};
 
 const errorMessage = 'path must be a string';
 
@@ -15,7 +19,7 @@ function makePathSafe(path) {
 
   // As Windows is the only non-UNIX like platform supported by node
   // https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1
-  if (isWindows()) {
+  if (isWindows) {
     if (isUncPath(safePath)) {
       return safePath.substring(pathModule.parse(safePath).root.length);
     } else {


### PR DESCRIPTION
When using this method on a `nodejs` installation running on a windows-machine, `path.resolve()` will always prefix your path with - not only the slash, like on unix-systems but also - with the character of the current mounted disk. In my case, this method, when called as `makePathSafe('test.js')`, it returned `C:/test.js`.

This value then always is joined with the path you registered as base-path. In my case it then turned out to be `C:/Users/Administrator/Downloads/C:/test.js`, which obviously has a `C:` too much 😉 

I've tried to remove it here, and it works in all the cases I could test it with. It removes the characters the root of this path has, which (in case of windows) is `C:/`. On a unix system, it only removes the `/` which anyways will be added using the `path.join()`.